### PR TITLE
Added Path resolving as a feature of the filesystems package.

### DIFF
--- a/src/main/java/com/simpleftp/FTPSystem.java
+++ b/src/main/java/com/simpleftp/FTPSystem.java
@@ -43,6 +43,11 @@ public class FTPSystem {
     private static final boolean debug = System.getProperty("simpleftp.debug") != null;
 
     /**
+     * Prevent instantiation
+     */
+    private FTPSystem() {}
+
+    /**
      * Allows the connection manager for this FTPSystem to be used throughout different classes.
      * @param connectionManager the connection manager to set
      */

--- a/src/main/java/com/simpleftp/filesystem/exceptions/PathResolverException.java
+++ b/src/main/java/com/simpleftp/filesystem/exceptions/PathResolverException.java
@@ -1,0 +1,64 @@
+/*
+ *  Copyright (C) 2020  Edward Lynch-Milner
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.simpleftp.filesystem.exceptions;
+
+import com.simpleftp.ftp.exceptions.FTPException;
+import lombok.Getter;
+
+import java.io.IOException;
+
+/**
+ * An exception indicating that resolving a path failed.
+ * Can only wrap an IOException or FTPException, or else an IllegalArgumentException is thrown.
+ * It uses the message from the wrapped exception.
+ * Used by paths.interfaces.PathResolver
+ */
+public class PathResolverException extends Exception {
+    @Getter
+    private final Exception wrappedException;
+
+    /**
+     * Constructs a PathResolverException with the specified exception
+     * @param wrappedException the IOException or FTPException this is wrapping
+     * @throws IllegalArgumentException if the wrappedException is not a FTPException or IOException
+     */
+    public PathResolverException(Exception wrappedException) throws IllegalArgumentException {
+        if (!(wrappedException instanceof IOException) && !(wrappedException instanceof FTPException)) {
+            throw new IllegalArgumentException("The provided exception must be an instance of IOException or FTPException");
+        }
+        this.wrappedException = wrappedException;
+    }
+
+    /**
+     * Gets the message of the wrapped exception as super(wrappedException.getMessage) was not called as the type of wrapped exception needed to be checked before super
+     * @return the message of the wrapped exception
+     */
+    @Override
+    public String getMessage() {
+        return wrappedException.getMessage();
+    }
+
+    /**
+     * Prints the stack trace with stderr
+     */
+    @Override
+    public void printStackTrace() {
+        System.err.println("PathResolverException wrapping:");
+        super.printStackTrace();
+    }
+}

--- a/src/main/java/com/simpleftp/filesystem/paths/LocalPathResolver.java
+++ b/src/main/java/com/simpleftp/filesystem/paths/LocalPathResolver.java
@@ -1,0 +1,97 @@
+/*
+ *  Copyright (C) 2020  Edward Lynch-Milner
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.simpleftp.filesystem.paths;
+
+import com.simpleftp.filesystem.LocalFile;
+import com.simpleftp.filesystem.exceptions.PathResolverException;
+import com.simpleftp.filesystem.paths.interfaces.PathResolver;
+import com.simpleftp.ui.UI;
+
+import java.io.File;
+import java.io.IOException;
+
+/*
+ * Represents a resolver for resolving local paths
+ */
+public class LocalPathResolver implements PathResolver {
+    /**
+     * The current working directory;
+     */
+    private final String currWorkingDir;
+
+    /**
+     * Constructs the LocalPathResolver. Outside the filesystem package, it is only instantiable from the PathResolverFactory
+     * @param currWorkingDir the current working directory
+     */
+    protected LocalPathResolver(String currWorkingDir) {
+        this.currWorkingDir = currWorkingDir;
+    }
+
+    /**
+     * Adds the current working directory to the path.
+     * @param path the path to be prepended
+     * @return the full path
+     */
+    private String addPwdToPath(String path) {
+        if (currWorkingDir.endsWith(UI.PATH_SEPARATOR)) {
+            path = currWorkingDir + path;
+        } else {
+            path = currWorkingDir + UI.PATH_SEPARATOR + path; // the current working directory should be an absolute path
+        }
+
+        return path;
+    }
+
+    /**
+     * Checks if the path is canonical
+     * @param path the path to check
+     * @return true if canonical
+     */
+    private boolean isPathCanonical(String path) {
+        String fileName = new LocalFile(path).getName();
+        return !path.contains("/..") && !path.contains("../")
+                && !path.contains("/.") && !path.contains("./")
+                && !path.equals("..") && !path.equals(".")
+                && !fileName.equals(".") && !fileName.equals("..");
+    }
+
+    /**
+     * Resolves the specified path to an absolute, canonicalized path
+     * @param path the path to resolve
+     * @return the ResolvedPath object
+     * @throws PathResolverException if an IOException occurs
+     */
+    @Override
+    public ResolvedPath resolvePath(String path) throws PathResolverException {
+        LocalFile file = new LocalFile(path);
+        boolean absolute = file.isAbsolute();
+        if (!absolute)
+            path = addPwdToPath(path);
+
+        try {
+            if (!isPathCanonical(path)) {
+                file = new LocalFile(path);
+                path = file.getCanonicalPath();
+            }
+
+            return new ResolvedPath(path, absolute);
+        } catch (IOException ex) {
+            throw new PathResolverException(ex);
+        }
+    }
+}

--- a/src/main/java/com/simpleftp/filesystem/paths/PathResolverFactory.java
+++ b/src/main/java/com/simpleftp/filesystem/paths/PathResolverFactory.java
@@ -1,0 +1,95 @@
+/*
+ *  Copyright (C) 2020  Edward Lynch-Milner
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.simpleftp.filesystem.paths;
+
+import com.simpleftp.filesystem.paths.interfaces.PathResolver;
+import com.simpleftp.ftp.connection.FTPConnection;
+
+/**
+ * A factory for creating a PathResolver
+ */
+public class PathResolverFactory {
+    /**
+     * The connection to use if remote
+     */
+    private FTPConnection connection;
+    /**
+     * If remote, this is required
+     */
+    private boolean pathExists;
+    /**
+     * True if building a local path resolver, false if remote
+     */
+    private boolean local;
+    /**
+     * The current working directory
+     */
+    private String currWorkingDir;
+
+    /**
+     * Don't allow instantiation using constructor
+     */
+    private PathResolverFactory() {}
+
+    /**
+     * Constructs a new factory
+     * @return returns the created factory
+     */
+    public static PathResolverFactory newInstance() {
+        return new PathResolverFactory();
+    }
+
+    /**
+     * Sets this factory to build a local path resolver with the specified current working directory
+     * @param currWorkingDir the current working directory
+     * @return the instance of the factory for chaining
+     */
+    public PathResolverFactory setLocal(String currWorkingDir) {
+        this.local = true;
+        this.currWorkingDir = currWorkingDir;
+        return this;
+    }
+
+    /**
+     * Sets this factory to build a remote path resolver with the specified current working directory
+     * @param currWorkingDir the current working directory
+     * @param connection the connection to use for resolving paths, expected to be connected and logged in and not null
+     * @param pathExists true if the path already exists, false if it is to be created
+     * @return this instance for chaining
+     */
+    public PathResolverFactory setRemote(String currWorkingDir, FTPConnection connection, boolean pathExists) {
+        this.local = false;
+        this.currWorkingDir = currWorkingDir;
+        this.connection = connection;
+        this.pathExists = pathExists;
+        return this;
+    }
+
+    /**
+     * Builds the PathResolver object
+     * @return the resolved path object
+     */
+    public PathResolver build() {
+        if (local) {
+            return new LocalPathResolver(currWorkingDir);
+        } else {
+            return new RemotePathResolver(connection, currWorkingDir, pathExists);
+        }
+    }
+
+}

--- a/src/main/java/com/simpleftp/filesystem/paths/RemotePathResolver.java
+++ b/src/main/java/com/simpleftp/filesystem/paths/RemotePathResolver.java
@@ -1,0 +1,165 @@
+/*
+ *  Copyright (C) 2020  Edward Lynch-Milner
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.simpleftp.filesystem.paths;
+
+import com.simpleftp.filesystem.LocalFile;
+import com.simpleftp.filesystem.exceptions.PathResolverException;
+import com.simpleftp.filesystem.paths.interfaces.PathResolver;
+import com.simpleftp.ftp.connection.FTPConnection;
+import com.simpleftp.ftp.exceptions.FTPException;
+import com.simpleftp.ui.UI;
+
+import java.io.File;
+
+/**
+ * This class represents a PathResolver for resolving remote paths
+ */
+public class RemotePathResolver implements PathResolver {
+    /**
+     * The connection to use for resolving paths
+     */
+    private final FTPConnection connection;
+    /**
+     * True if the path being resolved should already exist, false if not
+     */
+    private final boolean pathExists;
+    /**
+     * The current working directory
+     */
+    private final String currWorkingDir;
+
+    /**
+     * Constructs a RemotePathResolver for resolving remote paths. Needs to be created using factory outside of filesystem package
+     * @param connection the connection to be used to resolve paths
+     * @param currWorkingDir the current working directory
+     * @param pathExists true if the path should already exist, false if it is to be created
+     * @throws IllegalArgumentException if the connection is not ready (i.e. not connected and logged in)
+     */
+    protected RemotePathResolver(FTPConnection connection, String currWorkingDir, boolean pathExists) throws IllegalArgumentException {
+        this.connection = connection;
+        this.currWorkingDir = currWorkingDir;
+        this.pathExists = pathExists;
+
+        if (!(connection.isConnected() && connection.isLoggedIn())) {
+            throw new IllegalArgumentException("The provided connection must be connected and logged in");
+        }
+    }
+
+    /**
+     * Checks if the path is canonical
+     * @param path the path to check
+     * @return true if canonical
+     */
+    private boolean isPathCanonical(String path) {
+        String fileName = new LocalFile(path).getName();
+        return !path.contains("/..") && !path.contains("../")
+                && !path.contains("/.") && !path.contains("./")
+                && !path.equals("..") && !path.equals(".")
+                && !fileName.equals(".") && !fileName.equals("..");
+    }
+
+    /**
+     * Checks if the provided path is absolute or not
+     * @param path the path to check
+     * @return true if absolute, false if not
+     */
+    private boolean isPathAbsolute(String path) {
+        return path.startsWith("/");
+    }
+
+    /**
+     * Adds the current working directory to the path.
+     * @param path the path to be prepended
+     * @return the full path
+     */
+    private String addPwdToPath(String path) {
+        if (currWorkingDir.endsWith("/")) {
+            path = currWorkingDir + path;
+        } else {
+            path = currWorkingDir + "/" + path;
+        }
+
+        return path;
+    }
+
+    /**
+     * Converts the remote path to a canonical version. It is assumed the path is not canonical before hand.
+     * @param path the path to convert
+     * @return the absolute path version of path
+     * @throws FTPException if any FTPConnection methods throw an exception
+     */
+    private String canonicalizeRemotePath(String path) throws FTPException {
+        String fileName = new File(path).getName();
+
+        boolean isFile = true;
+        if (pathExists)
+            isFile = connection.remotePathExists(path, false);
+
+        String workingDir = isFile ? UI.getParentPath(path):path;
+        String oldWorkingDir = currWorkingDir;
+        connection.changeWorkingDirectory(workingDir); // allow the connection to resolve the . or .. by physically following the links
+        path = connection.getWorkingDirectory();
+        connection.changeWorkingDirectory(oldWorkingDir); // change back
+        boolean appendFileName = false;
+
+        if (!fileName.equals(".") && !fileName.equals("..")) {
+            if (pathExists) {
+                appendFileName = isFile;
+            } else {
+                appendFileName = true;
+            }
+        }
+
+        if (appendFileName) {
+            if (path.endsWith("/")) {
+                path += fileName;
+            } else {
+                path += "/" + fileName;
+            }
+        }
+
+        return path;
+    }
+
+    /**
+     * Resolves the specified path to an absolute, canonicalized path
+     *
+     * @param path           the path to resolve
+     * @return the ResolvedPath object
+     * @throws PathResolverException if a FTPException occurs
+     */
+    @Override
+    public ResolvedPath resolvePath(String path) throws PathResolverException {
+        if (path.startsWith("./"))
+            path = path.substring(2); // if it starts with ./, remove it and make the method look at this as a file starting in pwd
+        boolean absolute = isPathAbsolute(path);
+        if (!absolute)
+            path = addPwdToPath(path);
+        boolean canonical = isPathCanonical(path);
+
+        try {
+            if (!canonical) {
+                path = canonicalizeRemotePath(path);
+            }
+
+            return new ResolvedPath(path, absolute);
+        } catch (FTPException ex) {
+            throw new PathResolverException(ex);
+        }
+    }
+}

--- a/src/main/java/com/simpleftp/filesystem/paths/ResolvedPath.java
+++ b/src/main/java/com/simpleftp/filesystem/paths/ResolvedPath.java
@@ -1,0 +1,60 @@
+/*
+ *  Copyright (C) 2020  Edward Lynch-Milner
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.simpleftp.filesystem.paths;
+
+/**
+ * This class represents a path that has been resolved by a PathResolver.
+ * It consists of a path and a boolean value. The path is a canonical path and the boolean value represents if the path passed in was already absolute (can be canonicalized but doesn't need to be)
+ */
+public class ResolvedPath {
+    /**
+     * The resolved path
+     */
+    private String resolvedPath;
+    /**
+     * Flag indicating if the path passed in was already absolute
+     */
+    private boolean pathAlreadyAbsolute;
+
+    /**
+     * Creates a resolved path object
+     * @param resolvedPath the path that was resolved
+     * @param pathAlreadyAbsolute the flag indicating that the path passed into PathResolver.resolvePath was already absolute
+     */
+    public ResolvedPath(String resolvedPath, boolean pathAlreadyAbsolute) {
+        this.resolvedPath = resolvedPath;
+        this.pathAlreadyAbsolute = pathAlreadyAbsolute;
+    }
+
+    /**
+     * Gets the resolved path
+     * @return resolved path
+     */
+    public String getResolvedPath() {
+        return resolvedPath;
+    }
+
+    /**
+     * Returns whether the path passed into resolvePath was already absolute
+     * @return true if the path was already absolute, false if not
+     */
+    public boolean isPathAlreadyAbsolute() {
+        return pathAlreadyAbsolute;
+    }
+
+}

--- a/src/main/java/com/simpleftp/filesystem/paths/interfaces/PathResolver.java
+++ b/src/main/java/com/simpleftp/filesystem/paths/interfaces/PathResolver.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (C) 2020  Edward Lynch-Milner
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.simpleftp.filesystem.paths.interfaces;
+
+import com.simpleftp.filesystem.paths.ResolvedPath;
+import com.simpleftp.filesystem.exceptions.PathResolverException;
+
+// TODO test this interface more before committing and merging
+
+/**
+ * This interface provides a interface for resolving paths.
+ *
+ * It is up to the implementing classes to have methods to set any flags/fields that the resolvePath method requires.
+ * An example, remote path resolving requires an ready FTPConnection and a flag pathExists which determines if the path to be resolved doesn't exist yet or true if it does exist (for go to)
+ *
+ * These should be set using setters. If any flag isn't set, either leave as default false or throw an exception (i.e. have object Boolean and if null, throw). Fields like connection, if null, throw exception or revert to FTPSystem.getConnection
+ *
+ * This PathResolverException wraps any FTPException or IOException that can occur.
+ *
+ * A LocalPathResolver is a much simpler implementation than a RemotePathResolver.
+ */
+public interface PathResolver {
+    /**
+     * Resolves the specified path to an absolute, canonicalized path
+     * @param path the path to resolve
+     * @return the ResolvedPath object
+     * @throws PathResolverException if an IOException or FTPException occurs
+     */
+    ResolvedPath resolvePath(String path) throws PathResolverException;
+}

--- a/src/main/java/com/simpleftp/filesystem/paths/interfaces/package-info.java
+++ b/src/main/java/com/simpleftp/filesystem/paths/interfaces/package-info.java
@@ -1,0 +1,20 @@
+/*
+ *  Copyright (C) 2020  Edward Lynch-Milner
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+/**
+ * This package provides interfaces for the paths package
+ */
+package com.simpleftp.filesystem.paths.interfaces;

--- a/src/main/java/com/simpleftp/filesystem/paths/package-info.java
+++ b/src/main/java/com/simpleftp/filesystem/paths/package-info.java
@@ -1,0 +1,20 @@
+/*
+ *  Copyright (C) 2020  Edward Lynch-Milner
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+/**
+ * This package provides classes for working with paths, local or remote
+ */
+package com.simpleftp.filesystem.paths;

--- a/src/main/java/com/simpleftp/ui/panels/FilePanel.java
+++ b/src/main/java/com/simpleftp/ui/panels/FilePanel.java
@@ -352,6 +352,14 @@ public class FilePanel extends VBox {
     }
 
     /**
+     * Returns the path of the current working directory
+     * @return the current working directory path
+     */
+    public String getCurrentWorkingDirectory() {
+        return directory.getFilePath();
+    }
+
+    /**
      * Checks if the file represents a symbolic link and throws IllegalArgumentException if not
      * @param symbolicLink the file to check for being a link
      * @throws IllegalArgumentException if it is not a symbolic link
@@ -434,7 +442,12 @@ public class FilePanel extends VBox {
 
         try {
             String path = getSymLinkTargetPath(directory);
-            path = (String)parentContainer.pathToAbsolute(path, directory instanceof LocalFile, true)[0];
+            String currWorkingDir = this.directory.getFilePath();
+            if (directory instanceof LocalFile) {
+                path = UI.resolveLocalPath(path, currWorkingDir).getResolvedPath();
+            } else {
+                path = UI.resolveRemotePath(path, currWorkingDir, true, this.fileSystem.getFTPConnection()).getResolvedPath();
+            }
             CommonFile targetFile = fileSystem.getFile(path);
             setDirectory(targetFile);
             refresh();


### PR DESCRIPTION
Added the PathResolver interface which defines a way of resolving paths to a defined form. This consists of the following method:
`ResolvedPath String resolvePath(String path) throws PathResolverException;`

It is up to the specific implementations to define how a path is resolved and the variables it requires in advance to know how to resolve the path.

The 2 current implementations are LocalPathResolver and RemotePathResolver. Both these implementations define resolving a path as converting it to an absolute path and then to a canonical version. To do this, LocalPathResolver requires the variables:
- The path to resolve
- The current working directory at the point of resolving the path (it uses this to make the path absolute)
and RemotePathResolver requires:
- The path to resolve
- The current working directory at the point of resolving the path (it uses this to make the path absolute)
- A ready (connected and logged in) FTPConnection which will be used to build the canonical path
- A boolean flag pathExists is required. This flag determines the operation that requires the resolved path. A value of true indicates that this path already exists. This is useful for when the user specified a path to navigate to. A value of false indicates that the path is to be created. This is used for when creating new files and directories. This flag determines how the path is resolved.

These variables are used to "interpolate" the given variables into a single value which represents the resolved path

A factory (PathResolverFactory) has been created to create the appropriate PathResolver as the constructors for each implementation cannot be used outside the filesystem.paths package. This factory enforces that the required variables for path resolving as defined by the implementations are always provided.

This interface, hopefully, provides a much more reliable and maintainable way of resolving paths in the system than the method in FilePanelContainer previously used. That was poor design as FilePanelContainer's responsibility was not to resolve paths to their canonical version.