### PR TITLE
Improved LineEntry and added functionality to know if a file is open or not

### DIFF
--- a/src/main/java/com/simpleftp/filesystem/LocalFile.java
+++ b/src/main/java/com/simpleftp/filesystem/LocalFile.java
@@ -76,7 +76,7 @@ public class LocalFile extends File implements CommonFile {
         } else {
             LocalFile localFile = (LocalFile)obj;
 
-            return localFile.getFilePath().equals(localFile.getFilePath());
+            return this.getFilePath().equals(localFile.getFilePath());
         }
     }
 

--- a/src/main/java/com/simpleftp/filesystem/LocalFile.java
+++ b/src/main/java/com/simpleftp/filesystem/LocalFile.java
@@ -54,6 +54,32 @@ public class LocalFile extends File implements CommonFile {
         return super.isFile();
     }
 
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    /**
+     * Determines whether two CommonFiles are equal, either by hash code or path
+     *
+     * @return true if equals, false if not
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof LocalFile))
+            return false;
+
+        if (this == obj) {
+            return true;
+        } else if (this.hashCode() == obj.hashCode()) {
+            return true;
+        } else {
+            LocalFile localFile = (LocalFile)obj;
+
+            return localFile.getFilePath().equals(localFile.getFilePath());
+        }
+    }
+
     /**
      * Returns the size in bytes of the file
      *

--- a/src/main/java/com/simpleftp/filesystem/RemoteFile.java
+++ b/src/main/java/com/simpleftp/filesystem/RemoteFile.java
@@ -259,7 +259,7 @@ public class RemoteFile implements CommonFile {
         } else {
             RemoteFile remoteFile = (RemoteFile)obj;
 
-            return remoteFile.getFilePath().equals(remoteFile.getFilePath());
+            return this.getFilePath().equals(remoteFile.getFilePath());
         }
     }
 }

--- a/src/main/java/com/simpleftp/filesystem/RemoteFile.java
+++ b/src/main/java/com/simpleftp/filesystem/RemoteFile.java
@@ -31,7 +31,6 @@ import org.apache.commons.net.ftp.FTPFile;
 
 import java.io.File;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Properties;
 
 /**

--- a/src/main/java/com/simpleftp/filesystem/RemoteFile.java
+++ b/src/main/java/com/simpleftp/filesystem/RemoteFile.java
@@ -31,6 +31,7 @@ import org.apache.commons.net.ftp.FTPFile;
 
 import java.io.File;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Properties;
 
 /**
@@ -239,5 +240,26 @@ public class RemoteFile implements CommonFile {
         }
 
         return -1;
+    }
+
+
+    @Override
+    public int hashCode() {
+        return ftpFile.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof RemoteFile)) {
+            return false;
+        } else if (this == obj) {
+            return true;
+        } else if (this.hashCode() == obj.hashCode()) {
+            return true;
+        } else {
+            RemoteFile remoteFile = (RemoteFile)obj;
+
+            return remoteFile.getFilePath().equals(remoteFile.getFilePath());
+        }
     }
 }

--- a/src/main/java/com/simpleftp/filesystem/interfaces/CommonFile.java
+++ b/src/main/java/com/simpleftp/filesystem/interfaces/CommonFile.java
@@ -61,4 +61,17 @@ public interface CommonFile {
      * @return size in bytes of the file, -1 if could not be determined
      */
     long getSize() throws FileSystemException;
+
+    /**
+     * Returns the hashcode for this object
+     * @return the hash code
+     */
+    int hashCode();
+
+    /**
+     * Determines whether two CommonFiles are equal, either by hash code or path
+     * @param obj the object to compare to
+     * @return true if equals, false if not
+     */
+    boolean equals(Object obj);
 }

--- a/src/main/java/com/simpleftp/filesystem/paths/LocalPathResolver.java
+++ b/src/main/java/com/simpleftp/filesystem/paths/LocalPathResolver.java
@@ -22,7 +22,6 @@ import com.simpleftp.filesystem.exceptions.PathResolverException;
 import com.simpleftp.filesystem.paths.interfaces.PathResolver;
 import com.simpleftp.ui.UI;
 
-import java.io.File;
 import java.io.IOException;
 
 /*

--- a/src/main/java/com/simpleftp/filesystem/paths/RemotePathResolver.java
+++ b/src/main/java/com/simpleftp/filesystem/paths/RemotePathResolver.java
@@ -111,10 +111,9 @@ public class RemotePathResolver implements PathResolver {
             isFile = connection.remotePathExists(path, false);
 
         String workingDir = isFile ? UI.getParentPath(path):path;
-        String oldWorkingDir = currWorkingDir;
         connection.changeWorkingDirectory(workingDir); // allow the connection to resolve the . or .. by physically following the links
         path = connection.getWorkingDirectory();
-        connection.changeWorkingDirectory(oldWorkingDir); // change back
+        connection.changeWorkingDirectory(currWorkingDir); // change back
         boolean appendFileName = false;
 
         if (!fileName.equals(".") && !fileName.equals("..")) {

--- a/src/main/java/com/simpleftp/ui/UI.java
+++ b/src/main/java/com/simpleftp/ui/UI.java
@@ -30,7 +30,6 @@ import com.simpleftp.ftp.exceptions.*;
 import com.simpleftp.local.exceptions.LocalPathNotFoundException;
 import com.simpleftp.ui.dialogs.*;
 import com.simpleftp.ui.editor.FileEditorWindow;
-import com.simpleftp.ui.files.LineEntry;
 import com.simpleftp.ui.panels.FilePanel;
 import javafx.application.Platform;
 import javafx.concurrent.Service;

--- a/src/main/java/com/simpleftp/ui/UI.java
+++ b/src/main/java/com/simpleftp/ui/UI.java
@@ -30,6 +30,7 @@ import com.simpleftp.ftp.exceptions.*;
 import com.simpleftp.local.exceptions.LocalPathNotFoundException;
 import com.simpleftp.ui.dialogs.*;
 import com.simpleftp.ui.editor.FileEditorWindow;
+import com.simpleftp.ui.files.LineEntry;
 import com.simpleftp.ui.panels.FilePanel;
 import javafx.application.Platform;
 import javafx.concurrent.Service;
@@ -43,6 +44,8 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * This class provides static util methods and constants for UI
@@ -178,7 +181,12 @@ public final class UI {
     /**
      * List of background UI tasks running
      */
-    private static ArrayList<Service<?>> backgroundTasks = new ArrayList<>();
+    private static final ArrayList<Service<?>> backgroundTasks = new ArrayList<>();
+
+    /**
+     * List of paths of opened files
+     */
+    private static final Set<String> openedFiles = new HashSet<>();
 
     /**
      * Prevent instantiation
@@ -523,5 +531,33 @@ public final class UI {
         } catch (PathResolverException ex) {
             throw (FTPException)ex.getWrappedException();
         }
+    }
+
+    /**
+     * "Opens" this file by adding its path to the list of opened files. A LineEntry represents a file with a path, so more efficient to just pass in it's path
+     * This method doesn't check if the file exists on the file system
+     * @param filePath the path of the file that has been opened in the UI. When opening a LineEntry, just call lineEntry.getFilePath to retrieve the path
+     */
+    public static void openFile(final String filePath) {
+        openedFiles.add(filePath);
+    }
+
+    /**
+     * "Closes" this file by removing its path from the list of opened files. A LineEntry represents a file with a path, so more efficient to just pass in it's path
+     * This method does not check if the path exists on the file system
+     * @param filePath the path of the file that has been opened in the UI. When opening a LineEntry, just call lineEntry.getFilePath to retrieve the path
+     */
+    public static void closeFile(final String filePath) {
+        openedFiles.remove(filePath);
+    }
+
+    /**
+     * Checks if the specified file is opened in the UI. A LineEntry represents a file with a path, so more efficient to just pass in it's path.
+     * Note that this method does not check if the path exists on the file system
+     * @param filePath the path of the file to check. When opening a LineEntry, just call lineEntry.getFilePath to retrieve the path
+     * @return true if the file has been opened in the UI, false otherwise
+     */
+    public static boolean isFileOpened(final String filePath) {
+        return openedFiles.contains(filePath);
     }
 }

--- a/src/main/java/com/simpleftp/ui/containers/FilePanelContainer.java
+++ b/src/main/java/com/simpleftp/ui/containers/FilePanelContainer.java
@@ -567,16 +567,22 @@ public class FilePanelContainer extends VBox {
      */
     public void delete() {
         LineEntry lineEntry = getLineEntryFromComboBox();
+        CommonFile file = lineEntry.getFile();
+        String fileName = file.getName();
 
-        if (lineEntry != null) {
-            if (UI.doConfirmation("Confirm file deletion", "Confirm deletion of " + lineEntry.getFile().getName())) {
-                if (filePanel.deleteEntry(lineEntry)) {
-                    UI.doInfo("File deleted successfully", "File " + lineEntry.getFile().getName() + " deleted");
-                    comboBox.getItems().remove(lineEntry.getFile().getName());
-                } else {
-                    UI.doError("File not deleted", "File " + lineEntry.getFile().getName() + " wasn't deleted. FTP Reply: " + filePanel.getFileSystem().getFTPConnection().getReplyString());
+        if (!UI.isFileOpened(file.getFilePath())) {
+            if (lineEntry != null) {
+                if (UI.doConfirmation("Confirm file deletion", "Confirm deletion of " + fileName)) {
+                    if (filePanel.deleteEntry(lineEntry)) {
+                        UI.doInfo("File deleted successfully", "File " + fileName + " deleted");
+                        comboBox.getItems().remove(fileName);
+                    } else {
+                        UI.doError("File not deleted", "File " + fileName + " wasn't deleted. FTP Reply: " + filePanel.getFileSystem().getFTPConnection().getReplyString());
+                    }
                 }
             }
+        } else {
+            UI.doError("File Open", "File " + fileName + " is currently opened, file can't be deleted");
         }
     }
 

--- a/src/main/java/com/simpleftp/ui/editor/FileEditorWindow.java
+++ b/src/main/java/com/simpleftp/ui/editor/FileEditorWindow.java
@@ -293,6 +293,9 @@ public class FileEditorWindow extends VBox {
                     e.consume();
                     originalText = editor.getText(); // save the text that was there at the time, in case reset is pressed
                 }
+
+                if (!e.isConsumed())
+                    UI.closeFile(file.getFilePath());
             });
         } catch (Exception ex) {
             UI.doException(ex, UI.ExceptionType.EXCEPTION, FTPSystem.isDebugEnabled());

--- a/src/main/java/com/simpleftp/ui/editor/FileSaver.java
+++ b/src/main/java/com/simpleftp/ui/editor/FileSaver.java
@@ -274,7 +274,7 @@ class FileUploader extends Service<Void> {
             } else {
                 Platform.runLater(() -> {
                     editorWindow.setSave(false);
-                    UI.doError("Save Failed", "Failed to save file " + filePath + " as could not create backup " + backupPath);
+                    UI.doError("Save Failed", "Failed to save file " + filePath + " as could not create backup");
                 });
                 errorOccurred = true;
             }

--- a/src/main/java/com/simpleftp/ui/files/LineEntry.java
+++ b/src/main/java/com/simpleftp/ui/files/LineEntry.java
@@ -45,12 +45,10 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermission;
-import java.nio.file.attribute.PosixFilePermissions;
 import java.text.SimpleDateFormat;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Set;
-import java.util.TreeSet;
 
 /**
  * This is an abstract class representing a line entry on the panel.

--- a/src/main/java/com/simpleftp/ui/panels/FilePanel.java
+++ b/src/main/java/com/simpleftp/ui/panels/FilePanel.java
@@ -681,6 +681,8 @@ public class FilePanel extends VBox {
         menuItem2.setOnAction(e -> renameLineEntry(lineEntry));
         MenuItem menuItem3 = new MenuItem("Delete");
         menuItem3.setOnAction(e -> parentContainer.delete()); // right clicking this would have selected it in the container's combo box. So use containers delete method to display confirmation dialog
+                                                             // as a consequence, this method also checks if the file is open or not. If this call is to be changed to this.delete(), add the isOpen check and confirmation dialog to that method
+                                                            // this.delete doesn't remove the file from the combo box anyway (although refresh would get that)
         MenuItem menuItem4 = new MenuItem("Properties");
         menuItem4.setOnAction(e -> new FilePropertyWindow(lineEntry).show());
         contextMenu.getItems().addAll(menuItem1, menuItem2, menuItem3, menuItem4);


### PR DESCRIPTION
The following features have been implemented:
- LineEntry has been improved as the documentation surrounding it has been made clearer.
- For local line entries, it is now checked if the file system is a Posix compliant one and displays proper permissions. If not posix compliant, it just shows the access for the user running the program
- Functionality for a file being opened has been added and it works by adding the file path of the underlying file of the LineEntry to a set of open files. If a path is found to be open, rename and delete are blocked. Also, an info dialog pops up if trying to open an already opened file. On going up from a directory, that directory's path is closed. Storing file paths were chosen instead of storing LineEntries because, for the case of going up a directory, you would have to create a temp LineEntry to close it as all you have at the time of going up is the current CommonFile directory and its file path. Also in a FileEditorWindow it has a file, so rather than refactoring it to take a LineEntry, keep it as is and use the file path. This works as a LineEntry represents a file path at the lowest level anyway

This closes #71 and closes #73 