### PR TITLE
Added code for issue #78

### DIFF
--- a/src/main/java/com/simpleftp/filesystem/FileSystemUtils.java
+++ b/src/main/java/com/simpleftp/filesystem/FileSystemUtils.java
@@ -50,4 +50,21 @@ public final class FileSystemUtils {
         LocalDateTime localDateTime = LocalDateTime.of(year, month, day, hour, minute);
         return localDateTime.format(DateTimeFormatter.ofPattern(FILE_DATETIME_FORMAT));
     }
+
+    /**
+     * Constructs a path by prepending current working directory onto the given path separated with the specified separator
+     * @param currentWorkingDir the working directory to prepend
+     * @param path the path to prepend to
+     * @param pathSeparator the separator used for the paths
+     * @return the constructed path
+     */
+    public static String addPwdToPath(String currentWorkingDir, String path, String pathSeparator) {
+        if (currentWorkingDir.endsWith(pathSeparator)) {
+            path = currentWorkingDir + path;
+        } else {
+            path = currentWorkingDir + pathSeparator + path;
+        }
+
+        return path;
+    }
 }

--- a/src/main/java/com/simpleftp/filesystem/LocalFile.java
+++ b/src/main/java/com/simpleftp/filesystem/LocalFile.java
@@ -102,7 +102,7 @@ public class LocalFile extends File implements CommonFile {
             try {
                 String parent = getParent();
                 String windowsParent;
-                parent = parent == null ? ((windowsParent = System.getProperty("SystemDrive")) != null ? windowsParent:"/"):parent; // if windows, find the root
+                parent = parent == null ? ((windowsParent = System.getenv("SystemDrive")) != null ? windowsParent:"/"):parent; // if windows, find the root
 
                 String canonicalPath = PathResolverFactory.newInstance()
                         .setLocal(parent) // a symbolic link may be relative to the directory it's inside
@@ -259,7 +259,7 @@ public class LocalFile extends File implements CommonFile {
                 String path = Files.readSymbolicLink(toPath()).toString();
                 String parent = getParent();
                 String windowsParent;
-                parent = parent == null ? ((windowsParent = System.getProperty("SystemDrive")) != null ? windowsParent : "/") : parent; // if windows, find the root
+                parent = parent == null ? ((windowsParent = System.getenv("SystemDrive")) != null ? windowsParent : "/") : parent; // if windows, find the root
 
                 return PathResolverFactory.newInstance()
                         .setLocal(parent) // a symbolic link may be relative to the directory it's inside

--- a/src/main/java/com/simpleftp/filesystem/exceptions/PathResolverConfigurationException.java
+++ b/src/main/java/com/simpleftp/filesystem/exceptions/PathResolverConfigurationException.java
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (C) 2020  Edward Lynch-Milner
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.simpleftp.filesystem.exceptions;
+
+/**
+ * This exception is thrown by the PathResolverFactory
+ * It is a runtime unchecked exception and if thrown, it indicates an error using the PathResolverFactory
+ */
+public class PathResolverConfigurationException extends RuntimeException {
+    /**
+     * Constructs an exception object with the specified message
+     * @param message the message for this exception to display
+     */
+    public PathResolverConfigurationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/simpleftp/filesystem/paths/LocalPathResolver.java
+++ b/src/main/java/com/simpleftp/filesystem/paths/LocalPathResolver.java
@@ -17,6 +17,7 @@
 
 package com.simpleftp.filesystem.paths;
 
+import com.simpleftp.filesystem.FileSystemUtils;
 import com.simpleftp.filesystem.LocalFile;
 import com.simpleftp.filesystem.exceptions.PathResolverException;
 import com.simpleftp.filesystem.paths.interfaces.PathResolver;
@@ -42,29 +43,14 @@ public class LocalPathResolver implements PathResolver {
     }
 
     /**
-     * Adds the current working directory to the path.
-     * @param path the path to be prepended
-     * @return the full path
-     */
-    private String addPwdToPath(String path) {
-        if (currWorkingDir.endsWith(UI.PATH_SEPARATOR)) {
-            path = currWorkingDir + path;
-        } else {
-            path = currWorkingDir + UI.PATH_SEPARATOR + path; // the current working directory should be an absolute path
-        }
-
-        return path;
-    }
-
-    /**
      * Checks if the path is canonical
      * @param path the path to check
      * @return true if canonical
      */
     private boolean isPathCanonical(String path) {
         String fileName = new LocalFile(path).getName();
-        return !path.contains("/..") && !path.contains("../")
-                && !path.contains("/.") && !path.contains("./")
+        return !(path.contains("/..") || path.contains("\\..")) && !(path.contains("../") || path.contains("..\\"))
+                && !(path.contains("/.") || path.contains("\\.")) && !(path.contains("./") || path.contains(".\\"))
                 && !path.equals("..") && !path.equals(".")
                 && !fileName.equals(".") && !fileName.equals("..");
     }
@@ -78,11 +64,9 @@ public class LocalPathResolver implements PathResolver {
     @Override
     public String resolvePath(String path) throws PathResolverException {
         LocalFile file = new LocalFile(path);
-        if (path.startsWith("./"))
-            path = path.substring(2); // if it starts with ./, remove it and make the method look at this as a file starting in pwd
         boolean absolute = file.isAbsolute();
         if (!absolute)
-            path = addPwdToPath(path);
+            path = FileSystemUtils.addPwdToPath(currWorkingDir, path, UI.PATH_SEPARATOR);
 
         try {
             if (!isPathCanonical(path)) {

--- a/src/main/java/com/simpleftp/filesystem/paths/RemotePathResolver.java
+++ b/src/main/java/com/simpleftp/filesystem/paths/RemotePathResolver.java
@@ -17,6 +17,7 @@
 
 package com.simpleftp.filesystem.paths;
 
+import com.simpleftp.filesystem.FileSystemUtils;
 import com.simpleftp.filesystem.LocalFile;
 import com.simpleftp.filesystem.exceptions.PathResolverException;
 import com.simpleftp.filesystem.paths.interfaces.PathResolver;
@@ -84,21 +85,6 @@ public class RemotePathResolver implements PathResolver {
     }
 
     /**
-     * Adds the current working directory to the path.
-     * @param path the path to be prepended
-     * @return the full path
-     */
-    private String addPwdToPath(String path) {
-        if (currWorkingDir.endsWith("/")) {
-            path = currWorkingDir + path;
-        } else {
-            path = currWorkingDir + "/" + path;
-        }
-
-        return path;
-    }
-
-    /**
      * Converts the remote path to a canonical version. It is assumed the path is not canonical before hand.
      * @param path the path to convert
      * @return the absolute path version of path
@@ -147,11 +133,9 @@ public class RemotePathResolver implements PathResolver {
      */
     @Override
     public String resolvePath(String path) throws PathResolverException {
-        if (path.startsWith("./"))
-            path = path.substring(2); // if it starts with ./, remove it and make the method look at this as a file starting in pwd
         boolean absolute = isPathAbsolute(path);
         if (!absolute)
-            path = addPwdToPath(path);
+            path = FileSystemUtils.addPwdToPath(currWorkingDir, path, "/");
         boolean canonical = isPathCanonical(path);
 
         try {

--- a/src/main/java/com/simpleftp/filesystem/paths/SymbolicPathResolver.java
+++ b/src/main/java/com/simpleftp/filesystem/paths/SymbolicPathResolver.java
@@ -1,0 +1,124 @@
+/*
+ *  Copyright (C) 2020  Edward Lynch-Milner
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.simpleftp.filesystem.paths;
+
+import com.simpleftp.filesystem.paths.interfaces.PathResolver;
+
+import java.util.ArrayList;
+
+/**
+ * This is a PathResolver implementation which does a "loose" canonicalization of a path.
+ * What is meant by this is that it gets rid of all .. and . characters but doesn't need the path to exist.
+ * It also preserves following a path "symbolically", i.e. doesn't go to the target of the link, instead goes to the link as if it was a real directory at that location.
+ * On linux if you cd into a symbolic link, it follows it rather than going to the target (that is the -L flag of the cd command (default)).
+ * The Local and Remote PathResolvers behave as the -P option of cd command on linux (goes to targets).
+ *
+ * This resolver expects the path to be already absolute
+ */
+public class SymbolicPathResolver implements PathResolver {
+    /**
+     * The path separator to use when building strings
+     */
+    private final String pathSeparator;
+
+    /**
+     * The root to use at the start of the path.
+     * This can be null
+     */
+    private final String root;
+
+    /**
+     * Constructs a symbolic path resolver
+     * @param pathSeparator the path separator to use
+     * @param root the root at the start of the path. If the root of the path, e.g. on linux "/" isn't pathSeparator, specify here. E.g. it may be C:\ Otherwise leave null
+     */
+    protected SymbolicPathResolver(String pathSeparator, String root) {
+        this.pathSeparator = pathSeparator;
+        this.root = root;
+    }
+
+    /**
+     * Removes root if not null and present and splits the path into it's separate components
+     * @param path the path to split
+     * @return the array containing the split components
+     */
+    private String[] splitPath(String path) {
+        if (root != null && path.startsWith(root))
+            path = path.substring(root.length() - 1);
+        else if (path.startsWith(pathSeparator))
+            path = path.substring(1);
+        String regex = pathSeparator.equals("\\") ? "\\\\":pathSeparator;
+
+        return path.split(regex);
+    }
+
+    /**
+     * Parses the path into components and returns the list of components
+     * @param path the path to parse. Should be absolute
+     * @return the list of parsed path components to be built
+     */
+    private ArrayList<String> parsePath(String path) {
+        ArrayList<String> pathComponents = new ArrayList<>();
+        String[] components = splitPath(path);
+
+        for (String s : components) {
+            if (s.equals("..")) {
+                int size = pathComponents.size();
+                if (size != 0) {
+                    pathComponents.remove(size - 1);// .. means go to parent so remove the last added path component as the one before that component was the parent
+                }
+            } else if (!s.equals(".")) { // if it is equals to ., don't bother add it as it is the current directory
+                pathComponents.add(s);
+            }
+        }
+
+        return pathComponents;
+    }
+
+    /**
+     * Builds the path from the given list of path components
+     * @param pathComponents the components of the path to construct
+     * @return the built path
+     */
+    private String buildPath(ArrayList<String> pathComponents) {
+        StringBuilder path;
+        if (root != null) {
+            path = new StringBuilder(root);
+        } else {
+            path = new StringBuilder(pathSeparator); // initialise with path separator
+        }
+
+        pathComponents.forEach(e -> path.append(e).append(pathSeparator));
+        path.deleteCharAt(path.length() - 1);
+
+        return path.toString();
+    }
+
+    /**
+     * Resolves the specified path to an absolute, canonicalized path.
+     * As described in the class javadoc header, this is a "loose" canonicalization
+     *
+     * @param path the path to resolve
+     * @return the resolved path string
+     */
+    @Override
+    public String resolvePath(String path) {
+        ArrayList<String> pathComponents = parsePath(path);
+        return buildPath(pathComponents);
+    }
+}

--- a/src/main/java/com/simpleftp/ui/dialogs/SymbolicPathDialog.java
+++ b/src/main/java/com/simpleftp/ui/dialogs/SymbolicPathDialog.java
@@ -1,0 +1,60 @@
+/*
+ *  Copyright (C) 2020  Edward Lynch-Milner
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.simpleftp.ui.dialogs;
+
+import javafx.scene.control.Alert;
+import javafx.scene.control.ButtonBar;
+import javafx.scene.control.ButtonType;
+import javafx.scene.layout.Region;
+
+import java.util.Optional;
+
+/**
+ * This dialog is used to notify the user that they have entered a path that denotes they have entered a symbolic link.
+ * It gives the choice between going to the path specified, or the target of the link
+ */
+public class SymbolicPathDialog extends Alert {
+    /**
+     * Constructs a symbolic path dialog
+     * @param path the path that this dialog is for
+     */
+    public SymbolicPathDialog(String path) {
+        super(AlertType.CONFIRMATION);
+        setTitle("Symbolic Link");
+        setHeaderText("Symbolic Link Path");
+        setContentText("The path " + path + " entered represents a symbolic link. Do you want to go to the path or the target of the link?");
+        getDialogPane().setMinHeight(Region.USE_PREF_SIZE);
+        getButtonTypes().clear();
+        getButtonTypes().addAll(new ButtonType("Target Path", ButtonBar.ButtonData.CANCEL_CLOSE), new ButtonType("Specified Path", ButtonBar.ButtonData.OK_DONE));
+    }
+
+    /**
+     * SHows the dialog and returns the choice
+     * @return true indicates that they want to go to the specified path (default behaviour), false indicates to go to target path
+     */
+    public boolean showAndGetChoice() {
+        Optional<ButtonType> result = showAndWait();
+
+        if (result.isPresent()) {
+            ButtonType button = result.get();
+            return !button.getText().equals("Target Path"); // if it equals it, it will return false, else true
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/com/simpleftp/ui/editor/uploaders/FileUploader.java
+++ b/src/main/java/com/simpleftp/ui/editor/uploaders/FileUploader.java
@@ -75,7 +75,7 @@ public abstract class FileUploader extends Service<Void> {
                 FilePanel filePanel = editorWindow.getCreatingPanel();
                 String parentPath = new File(filePath).getParent();
                 String windowsParent;
-                parentPath = parentPath == null ? ((windowsParent = System.getProperty("SystemDrive")) != null ? windowsParent:"/"):parentPath; // if windows, find the root
+                parentPath = parentPath == null ? ((windowsParent = System.getenv("SystemDrive")) != null ? windowsParent:"/"):parentPath; // if windows, find the root
                 final String finalParent = parentPath;
 
                 // only refresh if the file we're saving is in out current working directory


### PR DESCRIPTION
This pull request closes #78.

Added a new path resolver SymbolicPathResolver which gives a "loose" version of canonicalization where it removes .. and . characters, but the path doesn't have to exist and any symbolic links are not followed. Hence the term loose as it is not technically the definition of canonical. This is required by the implementation of #78.

Now, if a path entered into go to is a symbolic link, a popup appears asking if the user wants to go to the path or to the target. If go to path is chosen, the symbolic resolver is used, else the path is resolved as true canonical.

The SYmbolicPathResolver implements the algorithm as seen in the comments in issue #78